### PR TITLE
build: add editorconfig, analyzers and CI formatting check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,50 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{cs,csx}]
+indent_size = 4
+
+# Namespaces and usings
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_using_directive_placement = outside_namespace:warning
+dotnet_sort_system_directives_first = false
+dotnet_separate_import_directive_groups = false
+
+# Prefer var when the type is apparent
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Modern C# preferences
+csharp_prefer_braces = true:suggestion
+csharp_style_prefer_primary_constructors = true:suggestion
+dotnet_style_prefer_collection_expression = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+
+[*.{json,yml,yaml,csproj,props,targets}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+# EF Core migrations are auto-generated; exclude from formatting/style rules
+[**/Migrations/*.cs]
+generated_code = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build & Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Verify formatting
+        run: dotnet format whitespace --verify-no-changes --no-restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore Golinks.slnf
 
       - name: Verify formatting
-        run: dotnet format whitespace --verify-no-changes --no-restore
+        run: dotnet format whitespace Golinks.slnf --verify-no-changes --no-restore
 
       - name: Build
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build Golinks.slnf --no-restore --configuration Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+</Project>

--- a/Golinks.Application/Requests/LinkMetricParams.cs
+++ b/Golinks.Application/Requests/LinkMetricParams.cs
@@ -1,4 +1,4 @@
-﻿namespace Golinks.Application.Requests;
+namespace Golinks.Application.Requests;
 
 public class LinkMetricParams
 {

--- a/Golinks.Application/Requests/LinkParams.cs
+++ b/Golinks.Application/Requests/LinkParams.cs
@@ -1,4 +1,4 @@
-﻿namespace Golinks.Application.Requests;
+namespace Golinks.Application.Requests;
 
 public class LinkParams
 {

--- a/Golinks.Domain/DTOs/MetricDTO.cs
+++ b/Golinks.Domain/DTOs/MetricDTO.cs
@@ -1,10 +1,8 @@
-﻿
-namespace Golinks.Domain.DTOs
+namespace Golinks.Domain.DTOs;
+
+public class MetricDTO
 {
-    public class MetricDTO
-    {
-        public Guid LinkId { get; set; }
-        public DateTime Date { get; set; }
-        public int TotalClicks { get; set; }
-    }
+    public Guid LinkId { get; set; }
+    public DateTime Date { get; set; }
+    public int TotalClicks { get; set; }
 }

--- a/Golinks.Domain/Entities/BaseEntity.cs
+++ b/Golinks.Domain/Entities/BaseEntity.cs
@@ -1,4 +1,4 @@
-﻿namespace Golinks.Domain.Entities;
+namespace Golinks.Domain.Entities;
 
 public abstract class BaseEntity
 {

--- a/Golinks.Domain/Entities/Metric.cs
+++ b/Golinks.Domain/Entities/Metric.cs
@@ -1,4 +1,4 @@
-﻿namespace Golinks.Domain.Entities;
+namespace Golinks.Domain.Entities;
 
 public class Metric : BaseEntity
 {

--- a/Golinks.Repository/Configurations/LinkConfiguration.cs
+++ b/Golinks.Repository/Configurations/LinkConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Golinks.Domain.Entities;
+using Golinks.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/Golinks.Repository/Configurations/MetricConfiguration.cs
+++ b/Golinks.Repository/Configurations/MetricConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Golinks.Domain.Entities;
+using Golinks.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/Golinks.Repository/Extensions/ApplicationBuilderExtensions.cs
+++ b/Golinks.Repository/Extensions/ApplicationBuilderExtensions.cs
@@ -1,21 +1,20 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Golinks.Repository.Extensions
+namespace Golinks.Repository.Extensions;
+
+[ExcludeFromCodeCoverage]
+public static class ApplicationBuilderExtensions
 {
-    [ExcludeFromCodeCoverage]
-    public static class ApplicationBuilderExtensions
+    public static void UseContextMigrations(this IApplicationBuilder app)
     {
-        public static void UseContextMigrations(this IApplicationBuilder app)
-        {
-            ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(app);
 
-            using var scope = app.ApplicationServices.CreateScope();
+        using var scope = app.ApplicationServices.CreateScope();
 
-            var context = scope.ServiceProvider.GetRequiredService<GolinksContext>();
-            context.Database.Migrate();
-        }
+        var context = scope.ServiceProvider.GetRequiredService<GolinksContext>();
+        context.Database.Migrate();
     }
 }

--- a/Golinks.Repository/GolinksContext.cs
+++ b/Golinks.Repository/GolinksContext.cs
@@ -1,4 +1,4 @@
-﻿using Golinks.Domain.Entities;
+using Golinks.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Reflection;

--- a/Golinks.Repository/GolinksContextFactory.cs
+++ b/Golinks.Repository/GolinksContextFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 

--- a/Golinks.WebAPI/Extensions/PermissionRequirementAttribute.cs
+++ b/Golinks.WebAPI/Extensions/PermissionRequirementAttribute.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Golinks.WebAPI.Extensions;
 

--- a/Golinks.WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/Golinks.WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/Golinks.slnf
+++ b/Golinks.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "Golinks.sln",
+    "projects": [
+      "Golinks.Application\\Golinks.Application.csproj",
+      "Golinks.Domain\\Golinks.Domain.csproj",
+      "Golinks.Repository\\Golinks.Repository.csproj",
+      "Golinks.WebAPI\\Golinks.WebAPI.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Introduces code style and linting tooling integrated with the build.

### Tooling
- **`.editorconfig`** — style rules aligned to the existing conventions (file-scoped namespaces, usings outside the namespace, 4-space indent, `var`/expression-bodied/collection-expression preferences). EF Core migrations are excluded as generated code.
- **`Directory.Build.props`** — enables .NET analyzers + `EnforceCodeStyleInBuild` for all projects as **warnings** (conservative profile: surfaces issues without breaking the build).
- **`.github/workflows/ci.yml`** — runs on pull requests to `master`: restore → `dotnet format whitespace --verify-no-changes` → Release build.

### Normalization applied
- UTF-8 BOM removal and final-newline fixes across 12 files (whitespace only).
- Two remaining block-scoped namespaces converted to file-scoped, making the codebase uniform.

## Why

There was no formatter or linter wired into the build, so style drift wasn't caught anywhere. This adds a predictable, low-friction gate.

## Notes for reviewers
- The CI gate enforces **whitespace only** (`dotnet format whitespace`). Full `dotnet format` was deliberately avoided because its analyzer pass applied unwanted semantic rewrites (e.g. making `DbSet<>` properties nullable). The analyzers still run during `dotnet build` as informational warnings.
- Migrations are excluded from formatting to avoid hundreds of lines of churn in generated files.
- `end_of_line` is intentionally not enforced in `.editorconfig` and the existing `.gitattributes` is untouched, to avoid fighting Git's autocrlf on Windows.
- Build is clean: 0 warnings, 0 errors; whitespace verification passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
